### PR TITLE
no error message for min or max values

### DIFF
--- a/spirack/D5a_module.py
+++ b/spirack/D5a_module.py
@@ -260,11 +260,13 @@ class D5a_module(object):
         if voltage >= maxV:
             bit_value = (2**18)-1
             self.voltages[DAC] = maxV
-            print("Voltage too high for set span, DAC set to max value")
+            if voltage > maxV:
+                print("Voltage too high for set span, DAC set to max value")
         elif voltage <= minV:
             self.voltages[DAC] = minV
             bit_value = 0
-            print("Voltage too low for set span, DAC set to min value")
+            if voltage < minV:
+                print("Voltage too low for set span, DAC set to min value")
 
         self.change_value_update(DAC, bit_value)
 


### PR DESCRIPTION
Setting, eg, a positive DAC to 0 results in the message "Voltage too low for set span, DAC set to max value", which is imho not necessary and can be annoying. Maybe changing the first if statement (line 260 and 265) to just > and < works as well, i didn't look at it in details